### PR TITLE
bump kubernetes client to 11.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ enum34==1.1.6
 google-auth==1.6.3
 idna==2.8
 ipaddress==1.0.22
-kubernetes==8.0.1
+kubernetes==11.0.0
 oauthlib==3.0.1
 pyasn1-modules==0.2.4
 pyasn1==0.4.5


### PR DESCRIPTION
As mentioned in https://github.com/getsentry/sentry-kubernetes/issues/32 kubernetes client is lagging behind and because of incompatible versions with the deployed kubernetes version in the cluster there are errors.
Errors that cause sentry client to stop reporting until it restarts.

As visible in the [kubernetes python client compatibility matrix](https://github.com/kubernetes-client/python#compatibility-matrix) they are not even showing compatibility for 8.x versions anymore. I'm taking that as an indication that 8.x is a thing of the past.

This pull request is bumping the client to latest.

----

Perhaps some mechanism could be contorted that might allow folks to specify which version of the client should be installed 🤷 